### PR TITLE
Optimise Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,13 @@ RUN apt-get update \
 
 RUN pip install --upgrade pip
 
-COPY urNode-backend/ /app
-
 WORKDIR /app
 
+# copy the requirement files earlier
+COPY urNode-backend/requirements /app/requirements
 RUN pip install --no-cache-dir --compile -r requirements/run-requirements.txt
+
+COPY urNode-backend/ /app
 
 EXPOSE 8000
 


### PR DESCRIPTION
pip install requirements step would be triggered on any change to the backend files, ideally that should happen only when the requirements file change.

so i reordered the steps so when the requirements file change, only then the pip install step is executed otherwise it utilises the build cache for that step if present.

doing this saves 111 seconds everytime you need to rebuild the image while developing.
(benchmarked on my laptop with good internet :p . you can imagine how much longer it would take on college net) 

 