### PR TITLE
Generate OpenAPI schema and place it into docs folder using GH Actions

### DIFF
--- a/.github/workflows/generate-api-schema.yml
+++ b/.github/workflows/generate-api-schema.yml
@@ -4,10 +4,14 @@ on:
     branches:
       - master
       - main # incase the master branch is ever renamed to main
+    paths:
+      - "urNode-backend/**"
   pull_request_target:
     branches:
       - master
       - main
+    paths:
+      - "urNode-backend/**"
 
 jobs:
   generate-schema:

--- a/.github/workflows/generate-api-schema.yml
+++ b/.github/workflows/generate-api-schema.yml
@@ -1,0 +1,42 @@
+name: Generate OpenAPI Schema for Redoc
+on:
+  push:
+    branches:
+      - master
+      - main # incase the master branch is ever renamed to main
+  pull_request:
+    branches:
+      - master
+      - main
+
+jobs:
+  generate-schema:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r urNode-backend/requirements/run-requirements.txt
+
+      # this edtion of the workflow uses Django's inbuilt generateschema to give us the schema file
+      - name: Generate the schema file
+        run: |
+          ./urNode-backend/ur_node/manage.py generateschema --title urNode --description Documentation --file docs/schema.yml
+
+      - name: Commit the generated schema
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: 🤖 commit the new OpenAPI schema
+          # this gives the commit author the github bot pfp and username
+          commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          file_pattern: 'docs/schema.yml'

--- a/.github/workflows/generate-api-schema.yml
+++ b/.github/workflows/generate-api-schema.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.head_ref }}
 
       - name: Set up python
         uses: actions/setup-python@v4

--- a/.github/workflows/generate-api-schema.yml
+++ b/.github/workflows/generate-api-schema.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
       - main # incase the master branch is ever renamed to main
-  pull_request:
+  pull_request_target:
     branches:
       - master
       - main


### PR DESCRIPTION
i've made the workflow file that'll generate the openAPI schema using the django cli and then place it into the docs directory and commit it.

I've tested this workflow in [`test-schema-ghaction` branch](https://github.com/RoguedBear/urNode/tree/test-schema-ghaction) in my fork.

Ideally this workflow will trigger when there's a push to main/master branch and on pull request branches that open towards main/master branch

--- 

closes #2 (i think? im not sure if the doc part is complete, will redoc automatically build and add this inside the sphinx docs now, as it happens with the IntelOwl docs?)