### PR TITLE
create docker images of the backend for kubernetes to use

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -6,11 +6,11 @@ on:
 
   # publish on pushes to the main branch (image tagged as "latest")
   push:
-    branches:
-      - main
-      - master
-#    paths:
-#      - "urNode-backend/**"
+#    branches:
+#      - main
+#      - master
+    paths:
+      - "urNode-backend/**"
   # allow manual triggers
   workflow_dispatch:
 

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -37,7 +37,7 @@ jobs:
         uses: macbre/push-to-ghcr@master
         with:
           image_name: ${REPO_LC}-backend
+          image_tag: ${TAG}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          tags: ${TAG}
           # optionally push to the Docker Hub (docker.io)
           # docker_io_token: ${{ secrets.DOCKER_IO_ACCESS_TOKEN }}  # see https://hub.docker.com/settings/security

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,35 @@
+name: Build and publish Docker image to ghcr.io
+on:
+  # publish on releases, e.g. v2.1.13 (image tagged as "2.1.13" - "v" prefix is removed)
+  release:
+    types: [published]
+
+  # publish on pushes to the main branch (image tagged as "latest")
+  push:
+    branches:
+      - main
+      - master
+#    paths:
+#      - "urNode-backend/**"
+  # allow manual triggers
+  workflow_dispatch:
+
+jobs:
+  docker_publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # https://github.community/t/github-actions-repository-name-must-be-lowercase/184924
+      - name: downcase REPO
+        run: |
+          echo "REPO_LC=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+      # https://github.com/marketplace/actions/push-to-ghcr
+      - name: Build and publish a Docker image for ${{ github.repository }}
+        uses: macbre/push-to-ghcr@master
+        with:
+          image_name: ${REPO_LC}-backend
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # optionally push to the Docker Hub (docker.io)
+          # docker_io_token: ${{ secrets.DOCKER_IO_ACCESS_TOKEN }}  # see https://hub.docker.com/settings/security

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -22,14 +22,22 @@ jobs:
       - uses: actions/checkout@v3
 
       # https://github.community/t/github-actions-repository-name-must-be-lowercase/184924
-      - name: downcase REPO
+      - name: downcase REPO & set branch/image tag name
         run: |
           echo "REPO_LC=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+          export "BRANCH=${GITHUB_REF##*/}"
+          if [ $BRANCH == "main" ] || [ $BRANCH == "master" ]; then
+            echo "TAG=latest" >> ${GITHUB_ENV};
+          else  
+            echo "TAG=${BRANCH}" >> ${GITHUB_ENV};
+          fi
+
       # https://github.com/marketplace/actions/push-to-ghcr
       - name: Build and publish a Docker image for ${{ github.repository }}
         uses: macbre/push-to-ghcr@master
         with:
           image_name: ${REPO_LC}-backend
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          tags: ${TAG}
           # optionally push to the Docker Hub (docker.io)
           # docker_io_token: ${{ secrets.DOCKER_IO_ACCESS_TOKEN }}  # see https://hub.docker.com/settings/security

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  docker_publish:
+  publish-backend-image-to-ghcr:
     runs-on: ubuntu-latest
 
     steps:
@@ -37,7 +37,7 @@ jobs:
         uses: macbre/push-to-ghcr@master
         with:
           image_name: ${REPO_LC}-backend
-          image_tag: ${TAG}
+          image_tag: ${{ env.TAG }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # optionally push to the Docker Hub (docker.io)
           # docker_io_token: ${{ secrets.DOCKER_IO_ACCESS_TOKEN }}  # see https://hub.docker.com/settings/security


### PR DESCRIPTION
I've created the workflow file that will generate a docker image using the Dockerfile present in the repository root.

workflow will be triggered when: 
- a file is changed in the `urNode-backend/` directory
-  or when you publish a release
- or if you manually trigger the workflow from the actions tab

earlier, i had the workflow to run only on master branch, but then I thought if you're developing on another branch and want to test those changes out, the workflow should have a way to handle that.

so what i've done is, 
- workflows run from the main/master branch will be tagged with `latest`
- workflows run from other branches will be tagged their respective branch name
- workflow triggered via release event will be tagged with the release tag you've used.

Also the images would be published to Github Container Registry, and you can view/manage them from the packages tab here:
![image](https://user-images.githubusercontent.com/39442192/198527860-a8c44b84-ddc0-446a-861c-147621410e24.png)

you can see example of that in my fork [here](https://github.com/RoguedBear/urNode/pkgs/container/urnode-backend)

example of different tags:
![image](https://user-images.githubusercontent.com/39442192/198528600-f2ad6af1-66e4-421b-ad83-0d6e24c533c7.png)


---

let me know if you want some changes say in the image name or anything else